### PR TITLE
temporarily unvisibleize Blogs

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -18,8 +18,8 @@ main:
   - title: "Experiences"
     url: "/#-experiences"
 
-  - title: "Blogs"
-    url: "/blog/"
+  # - title: "Blogs"
+  #   url: "/blog/"
 
   # - title: "Invited Talks"
   #   url: "/#-invited-talks"


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Hide the "Blogs" menu item by commenting out its entry in _data/navigation.yml